### PR TITLE
Remove timestamp in explainer youtube link

### DIFF
--- a/_recipes/renderstreams.md
+++ b/_recipes/renderstreams.md
@@ -33,4 +33,4 @@ Using ffmpeg, `dragonruby-replay` can take the `*.render` file and convert it in
 
 ## References
 
-- [Video explainer by Ryan C. Gordon](https://www.youtube.com/watch?v=6DT20eXnT88&t=39)
+- [Video explainer by Ryan C. Gordon](https://www.youtube.com/watch?v=6DT20eXnT88)


### PR DESCRIPTION
### Context

Extremely small change.

Was checking links across the site when I found this link to youtube with a timestamp that feels accidental and random at 39 seconds.

### Change

Remove the timestamp part of the youtube link to Ryan's video for a more smooth (less confusing) viewing.  This changes the link to just play from the start.